### PR TITLE
Added class decordator

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -831,12 +831,26 @@ class App:
                 Only when all the middleware call `next()` method, the listener function can be invoked.
         """
 
-        def __call__(*args, **kwargs):
-            functions = extract_listener_callables(kwargs) if kwargs else list(args)
-            slack_function = SlackFunction(self._register_listener, self._base_logger, callback_id)
-            return slack_function.register_listener(list(functions), matchers, middleware)
+        class SlackFunctionDecorator(SlackFunction):
+            def __init__(
+                self,
+                register_listener: Callable[..., Optional[Callable[..., Optional[BoltResponse]]]],
+                base_logger: logging.Logger,
+                callback_id: Union[str, Pattern],
+                matchers: Optional[Sequence[Callable[..., bool]]] = None,
+                middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
+            ):
+                super().__init__(register_listener, base_logger, callback_id)
+                self.matchers = matchers
+                self.middleware = middleware
 
-        return __call__
+            def __call__(self, *args, **kwargs):
+                if self.func is not None:
+                    return super().__call__(*args, **kwargs)
+                functions = extract_listener_callables(kwargs) if kwargs else list(args)
+                return self.register_listener(list(functions), self.matchers, self.middleware)
+
+        return SlackFunctionDecorator(self._register_listener, self._base_logger, callback_id, matchers, middleware)
 
     # -------------------------
     # slash commands

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -831,26 +831,7 @@ class App:
                 Only when all the middleware call `next()` method, the listener function can be invoked.
         """
 
-        class SlackFunctionDecorator(SlackFunction):
-            def __init__(
-                self,
-                register_listener: Callable[..., Optional[Callable[..., Optional[BoltResponse]]]],
-                base_logger: logging.Logger,
-                callback_id: Union[str, Pattern],
-                matchers: Optional[Sequence[Callable[..., bool]]] = None,
-                middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-            ):
-                super().__init__(register_listener, base_logger, callback_id)
-                self.matchers = matchers
-                self.middleware = middleware
-
-            def __call__(self, *args, **kwargs):
-                if self.func is not None:
-                    return super().__call__(*args, **kwargs)
-                functions = extract_listener_callables(kwargs) if kwargs else list(args)
-                return self.register_listener(list(functions), self.matchers, self.middleware)
-
-        return SlackFunctionDecorator(self._register_listener, self._base_logger, callback_id, matchers, middleware)
+        return SlackFunction(self._register_listener, self._base_logger, callback_id, matchers, middleware)
 
     # -------------------------
     # slash commands

--- a/tests/scenario_tests/test_function.py
+++ b/tests/scenario_tests/test_function.py
@@ -1,5 +1,6 @@
 import json
 import time
+import pytest
 
 from slack_sdk.signature import SignatureVerifier
 from slack_sdk.web import WebClient
@@ -99,6 +100,16 @@ class TestFunction:
         response = app.dispatch(request)
         assert response.status == 404
         assert_auth_test_count(self, 1)
+
+    def test_invalid_declaration(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func = app.function("reverse")
+
+        with pytest.raises(TypeError):
+            func("hello world")
 
 
 function_body = {

--- a/tests/scenario_tests/test_function_block_action.py
+++ b/tests/scenario_tests/test_function_block_action.py
@@ -144,6 +144,68 @@ class TestFunctionBlockActions:
         assert response.status == 404
         assert_auth_test_count(self, 1)
 
+    def test_success_decorators(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        @app.function("c")
+        def func_listener_wrap(body):
+            return func_listener(body)
+
+        @func_listener_wrap.action("a")
+        def simple_listener_wrap(ack, complete, body, payload, action, client: WebClient, context: BoltContext):
+            simple_listener(ack, complete, body, payload, action, client, context)
+
+        request = self.build_request_from_body(function_action_body)
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    def test_success_deconstructed_decorators(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+
+        @func
+        def func_listener_wrap(body):
+            return func_listener(body)
+
+        @func.action("a")
+        def simple_listener_wrap(ack, complete, body, payload, action, client: WebClient, context: BoltContext):
+            simple_listener(ack, complete, body, payload, action, client, context)
+
+        request = self.build_request_from_body(function_action_body)
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    def test_success_mixed_decorators(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+
+        @func
+        def func_listener_wrap(body):
+            return func_listener(body)
+
+        @func_listener_wrap.action("a")
+        def simple_listener_wrap(ack, complete, body, payload, action, client: WebClient, context: BoltContext):
+            simple_listener(ack, complete, body, payload, action, client, context)
+
+        request = self.build_request_from_body(function_action_body)
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
 
 function_action_body = {
     "type": "block_actions",

--- a/tests/scenario_tests/test_function_decorators.py
+++ b/tests/scenario_tests/test_function_decorators.py
@@ -68,3 +68,24 @@ class TestAppDecorators:
 
         handle_function_events({})
         assert isinstance(handle_function_events, Callable)
+
+    def test_initialized_decorators(self):
+        app = App(signing_secret=self.signing_secret, client=self.web_client)
+        ack = NoopAck()
+
+        func = app.function("c")
+
+        @func
+        def handle_function_events(body: dict):
+            assert body is not None
+
+        @func.action("some-func-action-id")
+        def handle_function_action(ack: Ack, body: dict):
+            assert body is not None
+            ack()
+
+        handle_function_action(ack, {})
+        assert isinstance(handle_function_action, Callable)
+
+        handle_function_events({})
+        assert isinstance(handle_function_events, Callable)


### PR DESCRIPTION
Instead of using a function as a decorator this uses a class as a decorator. This allows the following implementations to work correctly

```python
func = app.function("c")
@func 
def main_func():
    pass

@func.action("a")
def handle_actions():
    pass
```
```python
func = app.function("c")
@func 
def main_func():
    pass

@main_func.action("a")
def handle_actions():
    pass
```
```python
@app.function("c")
def main_func():
    pass

@main_func.action("a")
def handle_actions():
    pass
```
```python
func = app.function("c")(main_func)
func.action("a")(handle_actions)
```

**Concerns**:
1. Once the `function` decorator has been assigned to a python function it cannot be reassigned to another function this will simply not work

2. This prototype also allows slack function interactivity events to be registered without having the associated slack function registered