### PR TITLE
[feat] add function kwargs injection

### DIFF
--- a/slack_bolt/__init__.py
+++ b/slack_bolt/__init__.py
@@ -9,6 +9,8 @@ A Python framework to build Slack apps in a flash with the latest platform featu
 from .app import App
 from .context import BoltContext
 from .context.ack import Ack
+from .context.complete import Complete
+from .context.fail import Fail
 from .context.respond import Respond
 from .context.say import Say
 from .kwargs_injection import Args
@@ -21,6 +23,8 @@ __all__ = [
     "App",
     "BoltContext",
     "Ack",
+    "Complete",
+    "Fail",
     "Respond",
     "Say",
     "Args",

--- a/slack_bolt/context/async_context.py
+++ b/slack_bolt/context/async_context.py
@@ -4,6 +4,8 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_bolt.context.ack.async_ack import AsyncAck
 from slack_bolt.context.base_context import BaseContext
+from slack_bolt.context.complete.async_complete import AsyncComplete
+from slack_bolt.context.fail.async_fail import AsyncFail
 from slack_bolt.context.respond.async_respond import AsyncRespond
 from slack_bolt.context.say.async_say import AsyncSay
 from slack_bolt.util.utils import create_copy
@@ -122,3 +124,51 @@ class AsyncBoltContext(BaseContext):
                 ssl=self.client.ssl,
             )
         return self["respond"]
+
+    @property
+    def complete(self) -> AsyncComplete:
+        """`complete()` function for this request. Once a custom function's state is set to complete,
+        any outputs the function returns will be passed along to the next step of its housing workflow,
+        or complete the workflow if the function is the last step in a workflow. Additionally,
+        any interactivity handlers associated to a function invocation will no longer be invocable.
+
+            @app.function("reverse")
+            async def handle_button_clicks(ack, complete):
+                await ack()
+                await complete(outputs={"stringReverse":"olleh"})
+
+            @app.function("reverse")
+            async def handle_button_clicks(context):
+                await context.ack()
+                await context.complete(outputs={"stringReverse":"olleh"})
+
+        Returns:
+            Callable `complete()` function
+        """
+        if "complete" not in self:
+            self["complete"] = AsyncComplete(client=self.client, function_execution_id=self.function_execution_id)
+        return self["complete"]
+
+    @property
+    def fail(self) -> AsyncFail:
+        """`fail()` function for this request. Once a custom function's state is set to error,
+        its housing workflow will be interrupted and any provided error message will be passed
+        on to the end user through SlackBot. Additionally, any interactivity handlers associated
+        to a function invocation will no longer be invocable.
+
+            @app.function("reverse")
+            async def handle_button_clicks(ack, fail):
+                await ack()
+                await fail(error="something went wrong")
+
+            @app.function("reverse")
+            async def handle_button_clicks(context):
+                await context.ack()
+                await context.fail(error="something went wrong")
+
+        Returns:
+            Callable `fail()` function
+        """
+        if "fail" not in self:
+            self["fail"] = AsyncFail(client=self.client, function_execution_id=self.function_execution_id)
+        return self["fail"]

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -2,7 +2,7 @@
 # Note: Since 2021.12.8, the pytype code analyzer does not properly work for this file
 
 from logging import Logger
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from slack_bolt.authorization import AuthorizeResult
 
@@ -30,6 +30,7 @@ class BaseContext(dict):
         "bot_user_id",
         "user_token",
         "function_execution_id",
+        "inputs",
         "client",
         "ack",
         "say",
@@ -111,6 +112,11 @@ class BaseContext(dict):
     def function_execution_id(self) -> Optional[str]:
         """The `function_execution_id` associated with this request. Only available for function related events"""
         return self.get("function_execution_id")
+
+    @property
+    def inputs(self) -> Optional[Dict[str, Any]]:
+        """The `inputs` associated with this request. Only available for function related events"""
+        return self.get("inputs")
 
     # --------------------------------
 

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -34,6 +34,8 @@ class BaseContext(dict):
         "ack",
         "say",
         "respond",
+        "complete",
+        "fail",
     ]
 
     @property

--- a/slack_bolt/context/complete/__init__.py
+++ b/slack_bolt/context/complete/__init__.py
@@ -1,0 +1,6 @@
+# Don't add async module imports here
+from .complete import Complete
+
+__all__ = [
+    "Complete",
+]

--- a/slack_bolt/context/complete/async_complete.py
+++ b/slack_bolt/context/complete/async_complete.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict, Optional
+
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.web.async_slack_response import AsyncSlackResponse
+
+
+class AsyncComplete:
+    client: AsyncWebClient
+    function_execution_id: Optional[str]
+
+    def __init__(
+        self,
+        client: AsyncWebClient,
+        function_execution_id: Optional[str],
+    ):
+        self.client = client
+        self.function_execution_id = function_execution_id
+
+    async def __call__(self, outputs: Dict[str, Any] = {}) -> AsyncSlackResponse:
+        """Signal the successful completion of the custom function.
+
+        Kwargs:
+            outputs: Json serializable object containing the output values
+
+        Returns:
+            SlackResponse: The response object returned from slack
+
+        Raises:
+            ValueError: If this function cannot be used.
+        """
+        if self.function_execution_id is None:
+            raise ValueError("complete is unsupported here as there is no function_execution_id")
+
+        return await self.client.functions_completeSuccess(function_execution_id=self.function_execution_id, outputs=outputs)

--- a/slack_bolt/context/complete/complete.py
+++ b/slack_bolt/context/complete/complete.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict, Optional
+
+from slack_sdk import WebClient
+from slack_sdk.web import SlackResponse
+
+
+class Complete:
+    client: WebClient
+    function_execution_id: Optional[str]
+
+    def __init__(
+        self,
+        client: WebClient,
+        function_execution_id: Optional[str],
+    ):
+        self.client = client
+        self.function_execution_id = function_execution_id
+
+    def __call__(self, outputs: Dict[str, Any] = {}) -> SlackResponse:
+        """Signal the successful completion of the custom function.
+
+        Kwargs:
+            outputs: Json serializable object containing the output values
+
+        Returns:
+            SlackResponse: The response object returned from slack
+
+        Raises:
+            ValueError: If this function cannot be used.
+        """
+        if self.function_execution_id is None:
+            raise ValueError("complete is unsupported here as there is no function_execution_id")
+
+        return self.client.functions_completeSuccess(function_execution_id=self.function_execution_id, outputs=outputs)

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -5,6 +5,8 @@ from slack_sdk import WebClient
 
 from slack_bolt.context.ack import Ack
 from slack_bolt.context.base_context import BaseContext
+from slack_bolt.context.complete import Complete
+from slack_bolt.context.fail import Fail
 from slack_bolt.context.respond import Respond
 from slack_bolt.context.say import Say
 from slack_bolt.util.utils import create_copy
@@ -124,3 +126,51 @@ class BoltContext(BaseContext):
                 ssl=self.client.ssl,
             )
         return self["respond"]
+
+    @property
+    def complete(self) -> Complete:
+        """`complete()` function for this request. Once a custom function's state is set to complete,
+        any outputs the function returns will be passed along to the next step of its housing workflow,
+        or complete the workflow if the function is the last step in a workflow. Additionally,
+        any interactivity handlers associated to a function invocation will no longer be invocable.
+
+            @app.function("reverse")
+            def handle_button_clicks(ack, complete):
+                ack()
+                complete(outputs={"stringReverse":"olleh"})
+
+            @app.function("reverse")
+            def handle_button_clicks(context):
+                context.ack()
+                context.complete(outputs={"stringReverse":"olleh"})
+
+        Returns:
+            Callable `complete()` function
+        """
+        if "complete" not in self:
+            self["complete"] = Complete(client=self.client, function_execution_id=self.function_execution_id)
+        return self["complete"]
+
+    @property
+    def fail(self) -> Fail:
+        """`fail()` function for this request. Once a custom function's state is set to error,
+        its housing workflow will be interrupted and any provided error message will be passed
+        on to the end user through SlackBot. Additionally, any interactivity handlers associated
+        to a function invocation will no longer be invocable.
+
+            @app.function("reverse")
+            def handle_button_clicks(ack, fail):
+                ack()
+                fail(error="something went wrong")
+
+            @app.function("reverse")
+            def handle_button_clicks(context):
+                context.ack()
+                context.fail(error="something went wrong")
+
+        Returns:
+            Callable `fail()` function
+        """
+        if "fail" not in self:
+            self["fail"] = Fail(client=self.client, function_execution_id=self.function_execution_id)
+        return self["fail"]

--- a/slack_bolt/context/fail/__init__.py
+++ b/slack_bolt/context/fail/__init__.py
@@ -1,0 +1,6 @@
+# Don't add async module imports here
+from .fail import Fail
+
+__all__ = [
+    "Fail",
+]

--- a/slack_bolt/context/fail/async_fail.py
+++ b/slack_bolt/context/fail/async_fail.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.web.async_slack_response import AsyncSlackResponse
+
+
+class AsyncFail:
+    client: AsyncWebClient
+    function_execution_id: Optional[str]
+
+    def __init__(
+        self,
+        client: AsyncWebClient,
+        function_execution_id: Optional[str],
+    ):
+        self.client = client
+        self.function_execution_id = function_execution_id
+
+    async def __call__(self, error: str = "") -> AsyncSlackResponse:
+        """Signal that the custom function failed to complete.
+
+        Kwargs:
+            error: Error message to return to slack
+
+        Returns:
+            SlackResponse: The response object returned from slack
+
+        Raises:
+            ValueError: If this function cannot be used.
+        """
+        if self.function_execution_id is None:
+            raise ValueError("fail is unsupported here as there is no function_execution_id")
+
+        return await self.client.functions_completeError(function_execution_id=self.function_execution_id, error=error)

--- a/slack_bolt/context/fail/fail.py
+++ b/slack_bolt/context/fail/fail.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from slack_sdk import WebClient
+from slack_sdk.web import SlackResponse
+
+
+class Fail:
+    client: WebClient
+    function_execution_id: Optional[str]
+
+    def __init__(
+        self,
+        client: WebClient,
+        function_execution_id: Optional[str],
+    ):
+        self.client = client
+        self.function_execution_id = function_execution_id
+
+    def __call__(self, error: str = "") -> SlackResponse:
+        """Signal that the custom function failed to complete.
+
+        Kwargs:
+            error: Error message to return to slack
+
+        Returns:
+            SlackResponse: The response object returned from slack
+
+        Raises:
+            ValueError: If this function cannot be used.
+        """
+        if self.function_execution_id is None:
+            raise ValueError("fail is unsupported here as there is no function_execution_id")
+
+        return self.client.functions_completeError(function_execution_id=self.function_execution_id, error=error)

--- a/slack_bolt/kwargs_injection/args.py
+++ b/slack_bolt/kwargs_injection/args.py
@@ -120,7 +120,7 @@ class Args:
         # the naming conflict with the built-in one affects
         # only the internals of this method
         next: Callable[[], None],
-        **kwargs,  # noqa
+        **kwargs  # noqa
     ):
         self.logger: logging.Logger = logger
         self.client: WebClient = client

--- a/slack_bolt/kwargs_injection/args.py
+++ b/slack_bolt/kwargs_injection/args.py
@@ -5,6 +5,8 @@ from typing import Callable, Dict, Any, Optional
 
 from slack_bolt.context import BoltContext
 from slack_bolt.context.ack import Ack
+from slack_bolt.context.complete import Complete
+from slack_bolt.context.fail import Fail
 from slack_bolt.context.respond import Respond
 from slack_bolt.context.say import Say
 from slack_bolt.request import BoltRequest
@@ -82,6 +84,10 @@ class Args:
     """`say()` utility function, which calls `chat.postMessage` API with the associated channel ID"""
     respond: Respond
     """`respond()` utility function, which utilizes the associated `response_url`"""
+    complete: Complete
+    """`complete()` utility function, signals a successful completion of the custom function"""
+    fail: Fail
+    """`fail()` utility function, signal that the custom function failed to complete"""
     # middleware
     next: Callable[[], None]
     """`next()` utility function, which tells the middleware chain that it can continue with the next one"""
@@ -108,11 +114,13 @@ class Args:
         ack: Ack,
         say: Say,
         respond: Respond,
+        complete: Complete,
+        fail: Fail,
         # As this method is not supposed to be invoked by bolt-python users,
         # the naming conflict with the built-in one affects
         # only the internals of this method
         next: Callable[[], None],
-        **kwargs  # noqa
+        **kwargs,  # noqa
     ):
         self.logger: logging.Logger = logger
         self.client: WebClient = client
@@ -133,5 +141,7 @@ class Args:
         self.ack: Ack = ack
         self.say: Say = say
         self.respond: Respond = respond
+        self.complete: Complete = complete
+        self.fail: Fail = fail
         self.next: Callable[[], None] = next
         self.next_: Callable[[], None] = next

--- a/slack_bolt/kwargs_injection/async_args.py
+++ b/slack_bolt/kwargs_injection/async_args.py
@@ -116,7 +116,7 @@ class AsyncArgs:
         complete: AsyncComplete,
         fail: AsyncFail,
         next: Callable[[], Awaitable[None]],
-        **kwargs,  # noqa
+        **kwargs  # noqa
     ):
         self.logger: Logger = logger
         self.client: AsyncWebClient = client

--- a/slack_bolt/kwargs_injection/async_args.py
+++ b/slack_bolt/kwargs_injection/async_args.py
@@ -4,6 +4,8 @@ from typing import Callable, Awaitable, Dict, Any, Optional
 
 from slack_bolt.context.ack.async_ack import AsyncAck
 from slack_bolt.context.async_context import AsyncBoltContext
+from slack_bolt.context.complete.async_complete import AsyncComplete
+from slack_bolt.context.fail.async_fail import AsyncFail
 from slack_bolt.context.respond.async_respond import AsyncRespond
 from slack_bolt.context.say.async_say import AsyncSay
 from slack_bolt.request.async_request import AsyncBoltRequest
@@ -81,6 +83,10 @@ class AsyncArgs:
     """`say()` utility function, which calls chat.postMessage API with the associated channel ID"""
     respond: AsyncRespond
     """`respond()` utility function, which utilizes the associated `response_url`"""
+    complete: AsyncComplete
+    """`complete()` utility function, signals a successful completion of the custom function"""
+    fail: AsyncFail
+    """`fail()` utility function, signal that the custom function failed to complete"""
     # middleware
     next: Callable[[], Awaitable[None]]
     """`next()` utility function, which tells the middleware chain that it can continue with the next one"""
@@ -107,8 +113,10 @@ class AsyncArgs:
         ack: AsyncAck,
         say: AsyncSay,
         respond: AsyncRespond,
+        complete: AsyncComplete,
+        fail: AsyncFail,
         next: Callable[[], Awaitable[None]],
-        **kwargs  # noqa
+        **kwargs,  # noqa
     ):
         self.logger: Logger = logger
         self.client: AsyncWebClient = client
@@ -129,5 +137,7 @@ class AsyncArgs:
         self.ack: AsyncAck = ack
         self.say: AsyncSay = say
         self.respond: AsyncRespond = respond
+        self.complete: AsyncComplete = complete
+        self.fail: AsyncFail = fail
         self.next: Callable[[], Awaitable[None]] = next
         self.next_: Callable[[], Awaitable[None]] = next

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -52,6 +52,8 @@ def build_async_required_kwargs(
         "ack": request.context.ack,
         "say": request.context.say,
         "respond": request.context.respond,
+        "complete": request.context.complete,
+        "fail": request.context.fail,
         # middleware
         "next": next_func,
         "next_": next_func,  # for the middleware using Python's built-in `next()` function

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -52,6 +52,8 @@ def build_required_kwargs(
         "ack": request.context.ack,
         "say": request.context.say,
         "respond": request.context.respond,
+        "complete": request.context.complete,
+        "fail": request.context.fail,
         # middleware
         "next": next_func,
         "next_": next_func,  # for the middleware using Python's built-in `next()` function

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -276,20 +276,16 @@ app.step(ws)
                 default_message,
                 f"""
 @app.function("{callback_id}")
-{'async ' if is_async else ''}def handle_some_function(body, event, client, logger):
+{'async ' if is_async else ''}def handle_some_function(ack, body, complete, fail, logger):
+    {'await ' if is_async else ''}ack()
+    logger.info(body)
     try:
         # TODO: do something here
         outputs = {{}}
-        {'await ' if is_async else ''}client.functions_completeSuccess(
-            function_execution_id=context.function_execution_id,
-            outputs=outputs,
-        )
+        {'await ' if is_async else ''}complete(outputs=outputs)
     except Exception as e:
         error = f"Failed to handle a function request (error: {{e}})"
-        {'await ' if is_async else ''}client.functions_completeError(
-            function_execution_id=context.function_execution_id,
-            error=error,
-        )
+        {'await ' if is_async else ''}fail(error=error)
 """,
             )
         return _build_unhandled_request_suggestion(

--- a/slack_bolt/request/async_internals.py
+++ b/slack_bolt/request/async_internals.py
@@ -5,6 +5,7 @@ from slack_bolt.request.internals import (
     extract_enterprise_id,
     extract_function_bot_access_token,
     extract_function_execution_id,
+    extract_function_inputs,
     extract_is_enterprise_install,
     extract_team_id,
     extract_user_id,
@@ -49,6 +50,9 @@ def build_async_context(
         function_bot_access_token = extract_function_bot_access_token(body)
         if function_bot_access_token is not None:
             context["function_bot_access_token"] = function_bot_access_token
+        function_inputs = extract_function_inputs(body)
+        if function_inputs is not None:
+            context["inputs"] = function_inputs
     if "response_url" in body:
         context["response_url"] = body["response_url"]
     elif "response_urls" in body:

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -226,6 +226,14 @@ def extract_function_bot_access_token(payload: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def extract_function_inputs(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if payload.get("event") is not None:
+        return payload["event"].get("inputs")
+    if payload.get("function_data") is not None:
+        return payload["function_data"].get("inputs")
+    return None
+
+
 def build_context(context: BoltContext, body: Dict[str, Any]) -> BoltContext:
     context["is_enterprise_install"] = extract_is_enterprise_install(body)
     enterprise_id = extract_enterprise_id(body)
@@ -256,6 +264,9 @@ def build_context(context: BoltContext, body: Dict[str, Any]) -> BoltContext:
         function_bot_access_token = extract_function_bot_access_token(body)
         if function_bot_access_token is not None:
             context["function_bot_access_token"] = function_bot_access_token
+        inputs = extract_function_inputs(body)
+        if inputs is not None:
+            context["inputs"] = inputs
     if "response_url" in body:
         context["response_url"] = body["response_url"]
     elif "response_urls" in body:

--- a/tests/scenario_tests/test_function.py
+++ b/tests/scenario_tests/test_function.py
@@ -203,9 +203,10 @@ wrong_id_function_body = {
 }
 
 
-def reverse(body, event, context, client, complete):
+def reverse(body, event, context, client, complete, inputs):
     assert body == function_body
     assert event == function_body["event"]
+    assert inputs == function_body["event"]["inputs"]
     assert context.function_execution_id == "Fx111"
     assert complete.function_execution_id == "Fx111"
     assert context.function_bot_access_token == "xwfp-valid"

--- a/tests/scenario_tests/test_function.py
+++ b/tests/scenario_tests/test_function.py
@@ -203,26 +203,28 @@ wrong_id_function_body = {
 }
 
 
-def reverse(body, event, context, client):
+def reverse(body, event, context, client, complete):
     assert body == function_body
     assert event == function_body["event"]
     assert context.function_execution_id == "Fx111"
+    assert complete.function_execution_id == "Fx111"
     assert context.function_bot_access_token == "xwfp-valid"
     assert context.client.token == "xwfp-valid"
     assert client.token == "xwfp-valid"
-    client.functions_completeSuccess(
-        function_execution_id=event["function_execution_id"],
+    assert complete.client.token == "xwfp-valid"
+    complete(
         outputs={"reverseString": "olleh"},
     )
 
 
-def reverse_error(body, event, client, context):
+def reverse_error(body, event, fail):
     assert body == function_body
     assert event == function_body["event"]
-    client.functions_completeError(function_execution_id=event["function_execution_id"], error="there was an error")
+    assert fail.function_execution_id == "Fx111"
+    fail(error="there was an error")
 
 
-def complete_it(body, event, client):
+def complete_it(body, event, complete):
     assert body == function_body
     assert event == function_body["event"]
-    client.functions_completeSuccess(function_execution_id=event["function_execution_id"], outputs={})
+    complete(outputs={})

--- a/tests/scenario_tests_async/test_function.py
+++ b/tests/scenario_tests_async/test_function.py
@@ -58,7 +58,7 @@ class TestAsyncFunction:
     @pytest.mark.asyncio
     async def test_mock_server_is_running(self):
         resp = await self.web_client.api_test()
-        assert resp != None
+        assert resp is not None
 
     @pytest.mark.asyncio
     async def test_valid_callback_id_success(self):
@@ -207,32 +207,32 @@ wrong_id_function_body = {
 }
 
 
-async def reverse(body, event, client, context):
+async def reverse(body, event, client, context, complete):
     assert body == function_body
     assert event == function_body["event"]
     assert context.function_execution_id == "Fx111"
+    assert complete.function_execution_id == "Fx111"
     assert context.function_bot_access_token == "xwfp-valid"
     assert context.client.token == "xwfp-valid"
     assert client.token == "xwfp-valid"
-    await client.functions_completeSuccess(
-        function_execution_id=event["function_execution_id"],
+    assert complete.client.token == "xwfp-valid"
+    await complete(
         outputs={"reverseString": "olleh"},
     )
 
 
-async def reverse_error(body, event, client, context):
+async def reverse_error(body, event, fail):
     assert body == function_body
     assert event == function_body["event"]
-    await client.functions_completeError(
-        function_execution_id=event["function_execution_id"],
+    assert fail.function_execution_id == "Fx111"
+    await fail(
         error="there was an error",
     )
 
 
-async def complete_it(body, event, client):
+async def complete_it(body, event, complete):
     assert body == function_body
     assert event == function_body["event"]
-    await client.functions_completeSuccess(
-        function_execution_id=event["function_execution_id"],
+    await complete(
         outputs={},
     )

--- a/tests/scenario_tests_async/test_function.py
+++ b/tests/scenario_tests_async/test_function.py
@@ -207,9 +207,10 @@ wrong_id_function_body = {
 }
 
 
-async def reverse(body, event, client, context, complete):
+async def reverse(body, event, client, context, complete, inputs):
     assert body == function_body
     assert event == function_body["event"]
+    assert inputs == function_body["event"]["inputs"]
     assert context.function_execution_id == "Fx111"
     assert complete.function_execution_id == "Fx111"
     assert context.function_bot_access_token == "xwfp-valid"

--- a/tests/slack_bolt/context/test_complete.py
+++ b/tests/slack_bolt/context/test_complete.py
@@ -1,0 +1,32 @@
+import pytest
+
+from slack_sdk import WebClient
+from slack_bolt.context.complete import Complete
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestComplete:
+    def setup_method(self):
+        setup_mock_web_api_server(self)
+        valid_token = "xoxb-valid"
+        mock_api_server_base_url = "http://localhost:8888"
+        self.web_client = WebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+
+    def test_complete(self):
+        complete_success = Complete(client=self.web_client, function_execution_id="fn1111")
+
+        response = complete_success(outputs={"key": "value"})
+
+        assert response.status_code == 200
+
+    def test_complete_no_function_execution_id(self):
+        complete = Complete(client=self.web_client, function_execution_id=None)
+
+        with pytest.raises(ValueError):
+            complete(outputs={"key": "value"})

--- a/tests/slack_bolt/context/test_fail.py
+++ b/tests/slack_bolt/context/test_fail.py
@@ -1,0 +1,32 @@
+import pytest
+
+from slack_sdk import WebClient
+from slack_bolt.context.fail import Fail
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestFail:
+    def setup_method(self):
+        setup_mock_web_api_server(self)
+        valid_token = "xoxb-valid"
+        mock_api_server_base_url = "http://localhost:8888"
+        self.web_client = WebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+
+    def test_fail(self):
+        fail = Fail(client=self.web_client, function_execution_id="fn1111")
+
+        response = fail(error="something went wrong")
+
+        assert response.status_code == 200
+
+    def test_fail_no_function_execution_id(self):
+        fail = Fail(client=self.web_client, function_execution_id=None)
+
+        with pytest.raises(ValueError):
+            fail(error="there was an error")

--- a/tests/slack_bolt/kwargs_injection/test_args.py
+++ b/tests/slack_bolt/kwargs_injection/test_args.py
@@ -26,6 +26,8 @@ class TestArgs:
             "ack",
             "say",
             "respond",
+            "complete",
+            "fail",
             "next",
         ]
         arg_params: dict = build_required_kwargs(

--- a/tests/slack_bolt/logger/test_unmatched_suggestions.py
+++ b/tests/slack_bolt/logger/test_unmatched_suggestions.py
@@ -94,20 +94,16 @@ def handle_app_mention_events(body, logger):
 [Suggestion] You can handle this type of event with the following listener function:
 
 @app.function("reverse")
-def handle_some_function(body, event, client, logger):
+def handle_some_function(ack, body, complete, fail, logger):
+    ack()
+    logger.info(body)
     try:
         # TODO: do something here
         outputs = {{}}
-        client.functions_completeSuccess(
-            function_execution_id=context.function_execution_id,
-            outputs=outputs,
-        )
+        complete(outputs=outputs)
     except Exception as e:
         error = f"Failed to handle a function request (error: {{e}})"
-        client.functions_completeError(
-            function_execution_id=context.function_execution_id,
-            error=error,
-        )
+        fail(error=error)
 """
             == message
         )

--- a/tests/slack_bolt/request/test_internals.py
+++ b/tests/slack_bolt/request/test_internals.py
@@ -3,6 +3,7 @@ import pytest
 from slack_bolt.request.internals import (
     extract_channel_id,
     extract_function_bot_access_token,
+    extract_function_inputs,
     extract_user_id,
     extract_team_id,
     extract_enterprise_id,
@@ -90,16 +91,14 @@ class TestRequestInternals:
             "token": "xxx",
             "enterprise_id": "E111",
             "team_id": "T111",
-            "event": {"function_execution_id": "Fx111", "bot_access_token": "xwfp-xxx"},
+            "event": {"function_execution_id": "Fx111", "bot_access_token": "xwfp-xxx", "inputs": {"customer_id": "Ux111"}},
         },
         {
             "type": "block_actions",
             "enterprise_id": "E111",
             "team_id": "T111",
             "bot_access_token": "xwfp-xxx",
-            "function_data": {
-                "execution_id": "Fx111",
-            },
+            "function_data": {"execution_id": "Fx111", "inputs": {"customer_id": "Ux111"}},
             "interactivity": {"interactivity_pointer": "111.222.xxx"},
         },
         {
@@ -107,9 +106,7 @@ class TestRequestInternals:
             "enterprise_id": "E111",
             "team_id": "T111",
             "bot_access_token": "xwfp-xxx",
-            "function_data": {
-                "execution_id": "Fx111",
-            },
+            "function_data": {"execution_id": "Fx111", "inputs": {"customer_id": "Ux111"}},
             "interactivity": {"interactivity_pointer": "111.222.xxx"},
         },
     ]
@@ -334,6 +331,11 @@ class TestRequestInternals:
         for req in self.function_event_requests:
             function_execution_id = extract_function_execution_id(req)
             assert function_execution_id == "Fx111"
+
+    def test_function_inputs_extraction(self):
+        for req in self.function_event_requests:
+            inputs = extract_function_inputs(req)
+            assert inputs == {"customer_id": "Ux111"}
 
     def test_is_enterprise_install_extraction(self):
         for req in self.requests:

--- a/tests/slack_bolt_async/context/test_async_complete.py
+++ b/tests/slack_bolt_async/context/test_async_complete.py
@@ -1,0 +1,38 @@
+import pytest
+import asyncio
+
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_bolt.context.complete.async_complete import AsyncComplete
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestAsyncComplete:
+    @pytest.fixture
+    def event_loop(self):
+        setup_mock_web_api_server(self)
+        valid_token = "xoxb-valid"
+        mock_api_server_base_url = "http://localhost:8888"
+        self.web_client = AsyncWebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+        loop = asyncio.get_event_loop()
+        yield loop
+        loop.close()
+        cleanup_mock_web_api_server(self)
+
+    @pytest.mark.asyncio
+    async def test_complete(self):
+        complete_success = AsyncComplete(client=self.web_client, function_execution_id="fn1111")
+
+        response = await complete_success(outputs={"key": "value"})
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_complete_no_function_execution_id(self):
+        complete = AsyncComplete(client=self.web_client, function_execution_id=None)
+
+        with pytest.raises(ValueError):
+            await complete(outputs={"key": "value"})

--- a/tests/slack_bolt_async/context/test_async_fail.py
+++ b/tests/slack_bolt_async/context/test_async_fail.py
@@ -1,0 +1,38 @@
+import pytest
+import asyncio
+
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_bolt.context.fail.async_fail import AsyncFail
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestAsyncFail:
+    @pytest.fixture
+    def event_loop(self):
+        setup_mock_web_api_server(self)
+        valid_token = "xoxb-valid"
+        mock_api_server_base_url = "http://localhost:8888"
+        self.web_client = AsyncWebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+        loop = asyncio.get_event_loop()
+        yield loop
+        loop.close()
+        cleanup_mock_web_api_server(self)
+
+    @pytest.mark.asyncio
+    async def test_fail(self):
+        fail = AsyncFail(client=self.web_client, function_execution_id="fn1111")
+
+        response = await fail(error="something went wrong")
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_fail_no_function_execution_id(self):
+        fail = AsyncFail(client=self.web_client, function_execution_id=None)
+
+        with pytest.raises(ValueError):
+            await fail(error="there was an error")

--- a/tests/slack_bolt_async/kwargs_injection/test_async_args.py
+++ b/tests/slack_bolt_async/kwargs_injection/test_async_args.py
@@ -28,6 +28,8 @@ class TestAsyncArgs:
             "ack",
             "say",
             "respond",
+            "complete",
+            "fail",
             "next",
         ]
         arg_params: dict = build_async_required_kwargs(

--- a/tests/slack_bolt_async/logger/test_unmatched_suggestions.py
+++ b/tests/slack_bolt_async/logger/test_unmatched_suggestions.py
@@ -94,20 +94,16 @@ async def handle_app_mention_events(body, logger):
 [Suggestion] You can handle this type of event with the following listener function:
 
 @app.function("reverse")
-async def handle_some_function(body, event, client, logger):
+async def handle_some_function(ack, body, complete, fail, logger):
+    await ack()
+    logger.info(body)
     try:
         # TODO: do something here
         outputs = {{}}
-        await client.functions_completeSuccess(
-            function_execution_id=context.function_execution_id,
-            outputs=outputs,
-        )
+        await complete(outputs=outputs)
     except Exception as e:
         error = f"Failed to handle a function request (error: {{e}})"
-        await client.functions_completeError(
-            function_execution_id=context.function_execution_id,
-            error=error,
-        )
+        await fail(error=error)
 """
             == message
         )


### PR DESCRIPTION
This PR aims to add new kwargs injectction utilities for the function handler 

This PR introduced the `complete`, `fail` and `inputs` utility to help developers reduce boiler plate code

### Feedback

I'm looking for feedback on
- Usability, is this what we envisioned the developer experience would be?
- Does this aline with the Bolt-js experience?
- Implementation, does this implementation align with bolt principles
- Tests, are there any missing tests that could be valuable for the feature

### Testing

I created [this gist](https://gist.github.com/WilliamBergamin/e7ccc6ad4383b6883f832cbef2b6215a) to show how to test this new feature, use it for the following steps

1. Create a new app
    a. Head to https://api.slack.com/apps/?new_app=1
    b. Click "From an app manifest"
    c. Select YAML and paste the above manifest.yml content
    d. Click create button
2. Install the app into org/workspace
    a. Install the app anyways (when the workspace is in an Org, org-wide installation is required to publish functions)
    b. Grab the xoxb- token (Settings > Install App > Bot User OAuth Token)
    c. `export SLACK_BOT_TOKEN=xoxb-...`
3. Set up Socket Mode
    a. Head to Settings > Basic Information > App-Level Tokens on the https://api.slack.com/apps page
    b. Generate a new token with connections:write scope
    c. `export SLACK_APP_TOKEN=xapp-...`
4. Spin up the app
    a. Add `app.py` and `async_app.py` with the above source code
    b. Pull the latest PR branch of bolt python to your local
    c. Run `scripts/build_pypi_package.sh` this will generate a `.whl` in the `dist/` folder
    d. (Optional) In your project set up a venv with `python -m venv .venv` and `source .venv/bin/activate`
    e. `pip install global/path/to/bolt-python/dist/something.whl`
    f. `pip install aiohttp`
    g `python app.py` or `python async_app.py`
5. Add the custom step to a workflow
    a. Open the workflow builder
    b. Create a new workflow with a link trigger
    d. Seach "Hello" in the Steps view on the right side
    e. Add the step to the workflow (you can set any user ID as the input)
    f. Publish the workflow



### Category

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements 

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
